### PR TITLE
mdbtools argument compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,8 @@ Mdb.prototype.toCSV = function(table, cb) {
   )
 }
 
-Mdb.prototype.toSQL = function(table, cb) {
-  var cmd = spawn('mdb-export', ['-I -R ;\r\n', this.file, table])
+Mdb.prototype.toSQL = function(table, cb, backend) {
+  var cmd = spawn('mdb-export', ['-I', backend ? backend : 'mysql', this.file, table])
   cmd.stdout.pipe(
     concat(function(err, out) {
       if (err) return cb(err)
@@ -36,7 +36,7 @@ Mdb.prototype.toSQL = function(table, cb) {
 
 Mdb.prototype.tables = function(cb) {
   var self = this
-  var cmd = spawn('mdb-tables', ['-d' + this.tableDelimiter, this.file])
+  var cmd = spawn('mdb-tables', ['-d', this.tableDelimiter, this.file])
   cmd.stdout.pipe(
     concat(function(err, out) {
       if (err) return cb(err.toString())

--- a/readme.md
+++ b/readme.md
@@ -16,14 +16,53 @@ also as of this writing `mdbtools` supports `.mdb` and `.accdb` files up through
 
 ### usage
 
-    var fruit = mdb('fruit.mdb')
+#### Get tables
 
-    fruit.tables(function(err, tables) {
-      tables.forEach(function(table) {
-        fruit.toCSV(table, function(err, csv) {
-          console.log(err, table, csv.split('\n').length - 1 + " lines")
-        })
-      })
-    })
+    tables(callback)
+
+Example
+````javascript
+var fruit = mdb('fruit.mdb')
+fruit.tables(function(err, tables) {
+  tables.forEach(function (table) {
+    console.log(table);
+  });
+});
+````
+    
+#### Convert table rows to CSV rows
+
+    toCSV(table, callback)
+
+Example
+
+````javascript
+var fruit = mdb('fruit.mdb')
+fruit.tables(function(err, tables) {
+  tables.forEach(function(table) {
+    fruit.toCSV(table, function(err, csv) {
+      console.log(err, table, csv.split('\n').length - 1 + " lines")
+    });
+  });
+});
+````
+#### Convert table rows to SQL INSERT statements
+
+    toSQL(table, function, backend)
+    
+Currently defaults to `mdb-export -I mysql` "mysql" backend; so generates mysql compatible INSERT statements. See [mdb-export -I](https://github.com/brianb/mdbtools/blob/master/doc/mdb-export.txt) for more backends.
+
+````javascript
+var fruit = mdb('fruit.mdb')
+
+fruit.tables(function(err, tables) {
+  tables.forEach(function(table) {
+    fruit.toSQL(table, function(err, sql) {
+      console.log(err, table, sql.split('\n').length - 1 + " lines")
+    });
+  });
+});
+````
+
 
 MIT LICENSE


### PR DESCRIPTION
Fixed argument compatibility for mdbtools 0.7.1 (current + current via apt)

Note `toSQL` now has an extra parameter which is the type of sql required (access, sybase, oracle, postgres, mysql or sqlite, see [mdb-export -I](https://github.com/brianb/mdbtools/blob/master/doc/mdb-export.txt)
